### PR TITLE
Handle crypto and FERNET_KEY to enable connections to be encrypted

### DIFF
--- a/aws/cloud-formation-template.yml
+++ b/aws/cloud-formation-template.yml
@@ -871,12 +871,11 @@ Resources:
                   --no-cache-dir --compile --ignore-installed \
                   pycurl
                 SLUGIFY_USES_TEXT_UNIDECODE=yes pip3 install \
-                  apache-airflow[celery,postgres,s3]==1.10.2 \
+                  apache-airflow[celery,postgres,s3,crypto]==1.10.2 \
                   celery[sqs] \
                   billiard==3.5.0.4 \
                   tenacity==4.12.0 \
-                  cryptography==2.6.1 \
-                  crypto==1.4.1
+                  cryptography==2.6.1                 
         service:
           files:
             /usr/bin/turbine:

--- a/aws/cloud-formation-template.yml
+++ b/aws/cloud-formation-template.yml
@@ -875,7 +875,7 @@ Resources:
                   celery[sqs] \
                   billiard==3.5.0.4 \
                   tenacity==4.12.0 \
-                  cryptography==2.6.1                 
+                  cryptography==2.6.1
         service:
           files:
             /usr/bin/turbine:
@@ -908,6 +908,7 @@ Resources:
                   AIRFLOW__CELERY__RESULT_BACKEND=db+postgresql://${DbMasterUsername}:${DbMasterPassword}@${rds}/airflow
                   AIRFLOW__CELERY__WORKER_CONCURRENCY=${WorkerConcurrency}
                   AIRFLOW__CELERY_BROKER_TRANSPORT_OPTIONS__REGION=${AWS::Region}
+                  AIRFLOW__CORE__FERNET_KEY=INJECT_FERNET_KEY
                 - queue: !GetAtt
                     - Tasks
                     - QueueName
@@ -1004,7 +1005,8 @@ Resources:
             setup:
               command: !Sub |
                 cat /etc/environment >> /etc/sysconfig/airflow
-
+                
+                FERNET_KEY=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")
                 PUBLIC=$(curl -s -o /dev/null -w "%{http_code}" \
                   http://169.254.169.254/latest/meta-data/public-ipv4)
                 PUB_IPV4=$(ec2-metadata -v | awk '{print $2}')
@@ -1014,6 +1016,7 @@ Resources:
                 else HOST=$LOC_IPV4
                 fi
                 sed -i -e "s~INJECTHOST~$HOST~" /etc/sysconfig/airflow
+                sed -i -e "s~INJECT_FERNET_KEY~$FERNET_KEY~" /etc/sysconfig/airflow
 
                 sed 's/^/export /' -- </etc/sysconfig/airflow >/tmp/env.sh
                 source /tmp/env.sh

--- a/aws/cloud-formation-template.yml
+++ b/aws/cloud-formation-template.yml
@@ -874,8 +874,7 @@ Resources:
                   apache-airflow[celery,postgres,s3,crypto]==1.10.2 \
                   celery[sqs] \
                   billiard==3.5.0.4 \
-                  tenacity==4.12.0 \
-                  cryptography
+                  tenacity==4.12.0
         service:
           files:
             /usr/bin/turbine:

--- a/aws/cloud-formation-template.yml
+++ b/aws/cloud-formation-template.yml
@@ -1006,7 +1006,6 @@ Resources:
               command: !Sub |
                 cat /etc/environment >> /etc/sysconfig/airflow
                 
-                FERNET_KEY=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")
                 PUBLIC=$(curl -s -o /dev/null -w "%{http_code}" \
                   http://169.254.169.254/latest/meta-data/public-ipv4)
                 PUB_IPV4=$(ec2-metadata -v | awk '{print $2}')
@@ -1016,7 +1015,12 @@ Resources:
                 else HOST=$LOC_IPV4
                 fi
                 sed -i -e "s~INJECTHOST~$HOST~" /etc/sysconfig/airflow
-                sed -i -e "s~INJECT_FERNET_KEY~$FERNET_KEY~" /etc/sysconfig/airflow
+                
+                if [ ! -f /mnt/efs/fernet_key.txt ]; then
+                  FERNET_KEY=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)")
+                  echo $FERNET_KET > /mnt/efs/fernet_key.txt
+                  sed -i -e "s~INJECT_FERNET_KEY~$FERNET_KEY~" /etc/sysconfig/airflow
+                fi
 
                 sed 's/^/export /' -- </etc/sysconfig/airflow >/tmp/env.sh
                 source /tmp/env.sh

--- a/aws/cloud-formation-template.yml
+++ b/aws/cloud-formation-template.yml
@@ -874,7 +874,9 @@ Resources:
                   apache-airflow[celery,postgres,s3]==1.10.2 \
                   celery[sqs] \
                   billiard==3.5.0.4 \
-                  tenacity==4.12.0
+                  tenacity==4.12.0 \
+                  cryptography==2.6.1 \
+                  crypto==1.4.1
         service:
           files:
             /usr/bin/turbine:

--- a/aws/cloud-formation-template.yml
+++ b/aws/cloud-formation-template.yml
@@ -875,7 +875,7 @@ Resources:
                   celery[sqs] \
                   billiard==3.5.0.4 \
                   tenacity==4.12.0 \
-                  cryptography==2.6.1
+                  cryptography
         service:
           files:
             /usr/bin/turbine:


### PR DESCRIPTION
Fixes #83 

Get rid of the `Warning: Connection passwords are stored in plaintext until you install the Python "cryptography" library. You can find installation instructions here: https://cryptography.io/en/latest/installation/. Once installed, instructions for creating an encryption key will be displayed the next time you import Airflow.` message