### PR TITLE
fix filesystem issues after instance reboot

### DIFF
--- a/templates/turbine-cluster.template
+++ b/templates/turbine-cluster.template
@@ -521,7 +521,7 @@ Resources:
                 fspec="${EfsFileSystem}.efs.${AWS::Region}.amazonaws.com:/"
                 param="nfsvers=4.1,rsize=1048576,wsize=1048576"
                 param="$param,hard,timeo=600,retrans=2,noresvport"
-                echo "$fspec /mnt/efs nfs $param,_netdev 0 0" > /etc/fstab
+                echo "$fspec /mnt/efs nfs $param,_netdev 0 0" >> /etc/fstab
                 mount /mnt/efs
                 chown -R ec2-user /mnt/efs
         runtime:


### PR DESCRIPTION
fixes #114 .
was caused by fstab records being overwritten when writing the /mnt/efs.
changed to append the new record.