### PR TITLE
Automatic tagging for worker instances in ASG

### DIFF
--- a/aws/cloud-formation-template.yml
+++ b/aws/cloud-formation-template.yml
@@ -293,6 +293,10 @@ Resources:
         - Granularity: 1Minute
       VPCZoneIdentifier:
         - !Ref StackSubnet
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-worker'
+          PropagateAtLaunch: true
     Metadata:
       'AWS::CloudFormation::Designer':
         id: 90184717-25cc-4671-a70d-7becceed5c50


### PR DESCRIPTION
Worker instances are now automatically tagged with a Name by the Auto Scaling Group at launch time. This makes it easy to find worker instances in the AWS Console as well as provides tag consistency with the other instances (Scheduler and Webserver). 

More info about the Tag list property of AutoScalingGroups: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-tags.html

Without this change it's hard to identify worker instances in the AWS console as the Name field appears blank. 